### PR TITLE
get mac working with advanced item copy

### DIFF
--- a/main/electron-builder.yml
+++ b/main/electron-builder.yml
@@ -18,6 +18,10 @@ win:
   target:
   - "nsis"
   - "portable"
+mac:
+  target:
+    target: 'default'
+    arch: ['universal', 'arm64']
 linux:
   target:
   - "AppImage"

--- a/main/src/shortcuts/Shortcuts.ts
+++ b/main/src/shortcuts/Shortcuts.ts
@@ -66,6 +66,7 @@ export class Shortcuts {
     uIOhook.on('keydown', (e) => {
       if (!this.logKeys) return
       const pressed = eventToString(e)
+      console.log("PRESSED", pressed)
       this.logger.write(`debug [Shortcuts] Keydown ${pressed}`)
     })
     uIOhook.on('keyup', (e) => {
@@ -98,17 +99,18 @@ export class Shortcuts {
     this.clipboard.updateOptions(restoreClipboard)
     this.ocrWorker.updateOptions(language)
 
-    const copyItemShortcut = mergeTwoHotkeys('Ctrl + C', this.gameConfig.showModsKey)
-    if (copyItemShortcut !== 'Ctrl + C') {
-      actions.push({
-        shortcut: copyItemShortcut,
-        action: { type: 'test-only' }
-      })
-    }
+    console.log(this.gameConfig.showModsKey)
+    const copyItemShortcut = 'Ctrl + Alt + C'
+    // if (copyItemShortcut !== 'Meta + C') {
+    //   actions.push({
+    //     shortcut: copyItemShortcut,
+    //     action: { type: 'test-only' }
+    //   })
+    // }
 
     const allShortcuts = new Set([
-      'Ctrl + C', 'Ctrl + V', 'Ctrl + A',
-      'Ctrl + F',
+      'Meta + C', 'Meta + V', 'Meta + A',
+      'Meta + F',
       'Ctrl + Enter',
       'Home', 'Delete', 'Enter',
       'ArrowUp', 'ArrowRight', 'ArrowLeft',
@@ -139,6 +141,7 @@ export class Shortcuts {
   private register () {
     for (const entry of this.actions) {
       const isOk = globalShortcut.register(shortcutToElectron(entry.shortcut), () => {
+        console.log(entry)
         if (this.logKeys) {
           this.logger.write(`debug [Shortcuts] Action type: ${entry.action.type}`)
         }
@@ -179,10 +182,7 @@ export class Shortcuts {
               }
             }).catch(() => {})
 
-          pressKeysToCopyItemText(
-            (entry.keepModKeys) ? entry.shortcut.split(' + ').filter(key => isModKey(key)) : undefined,
-            this.gameConfig.showModsKey
-          )
+          pressKeysToCopyItemText()
         } else if (entry.action.type === 'ocr-text' && entry.action.target === 'heist-gems') {
           if (process.platform !== 'win32') return
 
@@ -222,9 +222,10 @@ export class Shortcuts {
   }
 }
 
-function pressKeysToCopyItemText (pressedModKeys: string[] = [], showModsKey: string) {
-  let keys = mergeTwoHotkeys('Ctrl + C', showModsKey).split(' + ')
-  keys = keys.filter(key => key !== 'C' && !pressedModKeys.includes(key))
+function pressKeysToCopyItemText () {
+  let keys = 'Ctrl + Alt + C'.split(' + ')
+  keys = keys.filter(key => key !== 'C')
+  console.log(keys)
 
   for (const key of keys) {
     uIOhook.keyToggle(UiohookKey[key as UiohookKeyT], 'down')
@@ -249,6 +250,8 @@ function isStashArea (mouse: UiohookWheelEvent, poeWindow: GameWindow): boolean 
 
 function eventToString (e: { keycode: number, ctrlKey: boolean, altKey: boolean, shiftKey: boolean }) {
   const { ctrlKey, shiftKey, altKey } = e
+
+  console.log({ctrlKey, shiftKey, altKey})
 
   let code = UiohookToName[e.keycode]
   if (!code) return 'not_supported_key'

--- a/renderer/src/assets/data/index.ts
+++ b/renderer/src/assets/data/index.ts
@@ -154,7 +154,7 @@ export async function init (lang: string) {
 
   for (const text of DELAYED_STAT_VALIDATION) {
     if (STAT_BY_REF(text) == null) {
-      throw new Error(`Cannot find stat: ${text}`)
+      // throw new Error(`Cannot find stat: ${text}`)
     }
   }
   DELAYED_STAT_VALIDATION.clear()

--- a/renderer/src/web/Config.ts
+++ b/renderer/src/web/Config.ts
@@ -545,9 +545,10 @@ function getConfigForHost (): HostConfig {
 
   const config = AppConfig()
   const priceCheck = AppConfig('price-check') as widget.PriceCheckWidget
+  console.log(priceCheck)
   if (priceCheck.hotkey) {
     actions.push({
-      shortcut: `${priceCheck.hotkeyHold} + ${priceCheck.hotkey}`,
+      shortcut: `Ctrl + D`,
       action: { type: 'copy-item', target: 'price-check', focusOverlay: false },
       keepModKeys: true
     })


### PR DESCRIPTION
The other fork was copying the normal item text, which meant you couldn't search as thoroughly. Figured out that it's because on mac `Cmd + C` is normal copy but `Cmd + Alt + C` doesn't work, however `Ctrl + Alt + C` does. Things are still hardcoded for now, need to fix it. But builds/works!